### PR TITLE
strip padding on udp

### DIFF
--- a/modules/turn/turn.c
+++ b/modules/turn/turn.c
@@ -215,6 +215,11 @@ static bool raw_handler(int proto, const struct sa *src,
 	if (mbuf_get_left(mb) < len)
 		return false;
 
+
+    // strip any optional padding
+    if (len != mbuf_get_left(mb))
+        mbuf_set_end(mb, mb->pos + len);
+
 	chan = chan_numb_find(al->chans, numb);
 	if (!chan)
 		return false;


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5766#section-11.5 allows udp clients to add padding to channeldata. This removes the padding.